### PR TITLE
Fix sorting in exercises

### DIFF
--- a/src/Exercises/Exercise01.cs
+++ b/src/Exercises/Exercise01.cs
@@ -20,6 +20,8 @@ public class Exercise01
             new() { Name = "Cherry", }
         };
 
-        return products.Select(p => p.Name).Order();
+        return products
+            .Select(p => p.Name)
+            .OrderBy(name => name);
     }
 }

--- a/src/Exercises/Exercise02.cs
+++ b/src/Exercises/Exercise02.cs
@@ -12,7 +12,7 @@ public class Exercise02
 
         var evenNumbers = numbers
             .Where(n => n % 2 == 0)
-            .Order()
+            .OrderBy(n => n)
             .ToList();
 
         return evenNumbers;

--- a/src/Exercises/Exercise03.cs
+++ b/src/Exercises/Exercise03.cs
@@ -24,7 +24,7 @@ public class Exercise03
         var topStudents = students
             .Where(s => s.Marks > 75)
             .Select(s => s.Name)
-            .Order()
+            .OrderBy(name => name)
             .ToList();
 
         return topStudents;

--- a/src/Exercises/Exercise04.cs
+++ b/src/Exercises/Exercise04.cs
@@ -12,7 +12,7 @@ namespace Exercises
 
             var longWords = words
                 .Where(w => w.Length > 4)
-                .OrderDescending()
+                .OrderByDescending(w => w)
                 .ToList();
 
             return longWords;

--- a/src/Exercises/Exercise15.cs
+++ b/src/Exercises/Exercise15.cs
@@ -17,7 +17,7 @@ public class Exercise15
         var valuesCount = values.Count();
 
         return values
-           .Order()
+           .OrderBy(v => v)
            .Skip((valuesCount - 1) / 2)
            .Take(2 - valuesCount % 2)
            .Average();


### PR DESCRIPTION
## Summary
- correct sorting logic across multiple exercises

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c56177d0883218e39848fcc49e6d8