### PR TITLE
Fix pluralization in Exercise13 description

### DIFF
--- a/src/Exercises/Exercise13.cs
+++ b/src/Exercises/Exercise13.cs
@@ -3,8 +3,8 @@ namespace Exercises;
 public class Exercise13
 {
     // Description:
-    // The given LINQ query retrieves a list of employees but does not identify the highest and lowest salary in each department.
-    // Enhance the query to group the employees by department and return the highest and lowest salary in each department.
+    // The given LINQ query retrieves a list of employees but does not identify the highest and lowest salaries in each department.
+    // Enhance the query to group the employees by department and return the highest and lowest salaries in each department.
 
     public class Employee
     {


### PR DESCRIPTION
## Summary
- update comments in `Exercise13` to correctly use plural "salaries"

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c8234f21c8321b28d3793b4cdcbb5